### PR TITLE
add docker-compose file and a sample data folder

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,7 @@
+# Ignore everything
+*
+
+# But not these files..
+!config.toml
+!.gitignore
+

--- a/data/config.toml
+++ b/data/config.toml
@@ -1,0 +1,18 @@
+# Every field in this config, and the file itself, is optional.
+# If you don't want to run the server with defaults, move this file to example.toml,
+# and change the fields as necessary.
+#
+# The server will run based on defaults if a field or the file is missing at runtime.
+
+# Cookie key should be cryptographically random. A key will be randomly generated at runtime
+# if this field is missing or if the key is less than 32 bytes.
+
+# Set secure cookies to true when running with HTTPS
+secure_cookies = false
+
+# Either metric or imperial
+units = "metric"
+
+disable_registration = false
+address = "0.0.0.0"
+port = 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,1 +1,1 @@
-docker/docker-comopse.yml
+docker/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,1 @@
+docker/docker-comopse.yml

--- a/docker/docker-comopse.yml
+++ b/docker/docker-comopse.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  tf-viewer:
+    container_name: tf-viewer
+    image: danielalvsaaker/tf-viewer:latest
+    build: .
+    environment:
+      - TZ=UTC
+    volumes: 
+      - ./data:/data
+    ports:
+      - "8080:8080"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   tf-viewer:
     container_name: tf-viewer
     image: danielalvsaaker/tf-viewer:latest
-    build: .
     environment:
       - TZ=UTC
     volumes: 


### PR DESCRIPTION
The aim is to provide an easy way to run the project.
The data folder is preconfigured to allow the start of the application from the root folder without any additional configuration.